### PR TITLE
Fixed bash script name, added HF_TOKEN environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,27 @@ be run on a GKE cluster as a container.
 pip install -r requirements.txt
 ```
 
-3. Download the ShareGPT dataset.
+3. Set your huggingface token as an enviornment variable
+
+```
+export HF_TOKEN=<your-huggingface-token>
+```
+
+4. Download the ShareGPT dataset.
 
 ```
 wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
 ```
 
-4. Run the benchmarking script directly with a specific request rate.
+5. Run the benchmarking script directly with a specific request rate.
 
 ```
 python3 --save-json-results --host=$IP  --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$REQUEST_RATE --backend=$BACKEND --num-prompts=$NUM_PROMPTS --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX
 ```
 
-5. Generate a full latency profile which generates latency and throughput data
+6. Generate a full latency profile which generates latency and throughput data
    at different request rates.
 
 ```
-./latency-profile-generation.sh
+./latency_throughput_curve.sh
 ```


### PR DESCRIPTION
README has the wrong name for the bash script. The bash script also expects $HF_TOKEN to be set as an environment variable, so added step to include it.