### PR TITLE
Pull latest changes / fixes from AI on GKE repo

### DIFF
--- a/latency_throughput_curve.sh
+++ b/latency_throughput_curve.sh
@@ -37,7 +37,10 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
     num_prompts=$(awk "BEGIN {print int($request_rate * $BENCHMARK_TIME_SECONDS)}")
   fi
   echo "TOTAL prompts: $num_prompts"  # Output: 8
-  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --output-bucket=$OUTPUT_BUCKET --host=$IP  --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP  --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
+  if [[ "$OUTPUT_BUCKET" ]]; then
+    PYTHON_OPTS="$PYTHON_OPTS --output-bucket=$OUTPUT_BUCKET"
+  fi
   if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
   fi


### PR DESCRIPTION
This pulls in the following changes:
- Benchmarking Tool Scrapes More vLLM Metrics (#937)
- Reduce CLIENT_TIMEOUT_SEC in benchmarking script (#932)
- Handle bucket not found exception in benchmarking script (#929)
- Make GCS bucket optional (#924)
- Fix divide by zero exception for responses of length 1 (#902)
- Split TPOT into two metrics, one with first token latency and one without (#900)
- TTFT Prometheus Metric (#881)
- Benchmarking script shouldn't choose same prompts every time (#895)