### PR TITLE
Correctly filter pod monitoring by name and namespace; add more vllm metrics; fix a bug

### DIFF
--- a/latency_throughput_curve.sh
+++ b/latency_throughput_curve.sh
@@ -40,7 +40,7 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
   echo "TOTAL prompts: $num_prompts"
   
   # Build the python command options
-  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS --pm-namespace=$PM_NAMESPACE --pm-job=$PM_JOB"
 
   if [[ "$TRAFFIC_SPLIT" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --traffic-split=$TRAFFIC_SPLIT"


### PR DESCRIPTION

## Testing

I tested this change by building a new image, and deployed it via the following yaml, and got the following results.

### Example output 
Notice the new vllm metrics.

```
{
    "metrics": {
        "num_prompts_attempted": 600,
        "num_prompts_succeeded": 600,
        "request_rate": 10.0,
        "server_metrics": {
            "vllm:cpu_cache_usage_perc": {
                "Mean": 0.0,
                "Median": 0.0,
                "Sd": 0.0,
                "Min": 0.0,
                "Max": 0.0,
                "P90": 0.0,
                "P95": 0.0,
                "P99": 0.0
            },
            "vllm:gpu_cache_usage_perc": {
                "Mean": 0.010362638890374178,
                "Median": 0.005143889892951448,
                "Sd": 0.012740202906789195,
                "Min": 0.0,
                "Max": 0.03628527735298204,
                "P90": 0.031113582649798407,
                "P95": 0.03436674544696229,
                "P99": 0.03590157097177809
            },
            "vllm:num_requests_waiting": {
                "Mean": 0.0,
                "Median": 0.0,
                "Sd": 0.0,
                "Min": 0.0,
                "Max": 0.0,
                "P90": 0.0,
                "P95": 0.0,
                "P99": 0.0
            },
            "vllm:num_requests_running": {
                "Mean": 3.1538461538461537,
                "Median": 2.0,
                "Sd": 3.393345384632735,
                "Min": 0.0,
                "Max": 10.0,
                "P90": 7.800000000000001,
                "P95": 8.799999999999997,
                "P99": 9.759999999999998
            },
            "vllm:num_requests_swapped": {
                "Mean": 0.0,
                "Median": 0.0,
                "Sd": 0.0,
                "Min": 0.0,
                "Max": 0.0,
                "P90": 0.0,
                "P95": 0.0,
                "P99": 0.0
            },
            "vllm:time_to_first_token_seconds": {
                "Mean": 0.014414878252846071,
                "Median": 0.014897540983606558,
                "Min": 0.005,
                "Max": 0.04,
                "P90": 0.028454545454545448,
                "P95": 0.034227272727272724,
                "P99": 0.03885161290322581
            },
            "vllm:time_per_output_token_seconds": {
                "Mean": 0.008046654010807093,
                "Median": 0.01,
                "Min": 0.01,
                "Max": 0.075,
                "P90": 0.01,
                "P95": 0.011486734359646242,
                "P99": 0.022729708483458885
            },
            "vllm:e2e_request_latency_seconds": {
                "Mean": 1.3022925841197954,
                "Median": 0.531578947368421,
                "Min": 0.3,
                "Max": 10.0,
                "P90": 4.046296296296296,
                "P95": 4.893518518518517,
                "P99": 8.856249999999992
            },
            "vllm:request_prefill_time_seconds": {
                "Mean": 0.013978034286639312,
                "Median": 0.3,
                "Min": 0.3,
                "Max": 0.3,
                "P90": 0.3,
                "P95": 0.3,
                "P99": 0.3
            },
            "vllm:request_queue_time_seconds": {
                "Mean": 0.00046149147064601355,
                "Median": 0.3,
                "Min": 0.3,
                "Max": 0.3,
                "P90": 0.3,
                "P95": 0.3,
                "P99": 0.3
            },
            "vllm:request_decode_time_seconds": {
                "Mean": 1.28785305836251,
                "Median": 0.49375,
                "Min": 0.3,
                "Max": 10.0,
                "P90": 4.046296296296296,
                "P95": 4.893518518518517,
                "P99": 8.856249999999992
            },
            "vllm:request_inference_time_seconds": {
                "Mean": 1.3018310926491494,
                "Median": 0.531578947368421,
                "Min": 0.3,
                "Max": 10.0,
                "P90": 4.046296296296296,
                "P95": 4.9475,
                "P99": 8.934374999999992
            },
            "vllm:time_in_queue_requests": {
                "Mean": 0.00046411749258028835,
                "Median": 0.3,
                "Min": 0.3,
                "Max": 0.3,
                "P90": 0.3,
                "P95": 0.3,
                "P99": 0.3
            },
            "vllm:request_prompt_tokens": {
                "Mean": 252.75977334820323,
                "Median": 110.60606060606061,
                "Min": 2.0,
                "Max": 2000.0,
                "P90": 774.264705882353,
                "P95": 890.8088235294116,
                "P99": 984.0441176470587
            },
            "vllm:request_generation_tokens": {
                "Mean": 166.21437556734762,
                "Median": 75.83333333333334,
                "Min": 1.0,
                "Max": 2000.0,
                "P90": 463.23943661971833,
                "P95": 662.4999999999995,
                "P99": 950.6818181818178
            },
            "vllm:iteration_tokens_total": {
                "Mean": 14.337578923877231,
                "Median": 5.411441418935798,
                "Min": 1.0,
                "Max": 1104.0,
                "P90": 12.87690447400242,
                "P95": 15.052720677146311,
                "P99": 352.08000000000175
            },
            "vllm:prompt_tokens_total": {
                "Sum": 391841.0,
                "Rate": 588.0606060606061,
                "Increase": 38812.0,
                "Mean": 660.9295606060607,
                "Max": 660.9295606060607,
                "Min": 660.9295606060607,
                "P90": 660.9295606060607,
                "P95": 660.9295606060607,
                "P99": 660.9295606060607
            },
            "vllm:generation_tokens_total": {
                "Sum": 236697.0,
                "Rate": 284.23939393939395,
                "Increase": 18759.8,
                "Mean": 368.7026515151515,
                "Max": 368.7026515151515,
                "Min": 368.7026515151515,
                "P90": 368.7026515151515,
                "P95": 368.7026515151515,
                "P99": 368.7026515151515
            },
            "vllm:request_success_total": {
                "Sum": 867.0,
                "Rate": 1.2575757575757576,
                "Increase": 83.0,
                "Mean": 1.6864848484848487,
                "Max": 1.6864848484848487,
                "Min": 1.6864848484848487,
                "P90": 1.6864848484848487,
                "P95": 1.6864848484848487,
                "P99": 1.6864848484848487
            },
            "vllm:num_preemptions_total": {
                "Sum": 0.0,
                "Rate": 0.0,
                "Increase": 0.0,
                "Mean": 0.0,
                "Max": 0.0,
                "Min": 0.0,
                "P90": 0.0,
                "P95": 0.0,
                "P99": 0.0
            },
            "vllm:cpu_prefix_cache_hit_rate": {
                "Mean": -1.0,
                "Median": -1.0,
                "Sd": 0.0,
                "Min": -1.0,
                "Max": -1.0,
                "P90": -1.0,
                "P95": -1.0,
                "P99": -1.0
            },
            "vllm:gpu_prefix_cache_hit_rate": {
                "Mean": -1.0,
                "Median": -1.0,
                "Sd": 0.0,
                "Min": -1.0,
                "Max": -1.0,
                "P90": -1.0,
                "P95": -1.0,
                "P99": -1.0
            },
            "vllm:avg_generation_throughput_toks_per_s": {
                "Mean": 347.3894517669663,
                "Median": 448.05034523248315,
                "Sd": 342.1900726799975,
                "Min": 0.0,
                "Max": 973.2688946803107,
                "P90": 781.0666048316662,
                "P95": 893.4047165544076,
                "P99": 957.2960590551301
            },
            "vllm:avg_prompt_throughput_toks_per_s": {
                "Mean": 602.4019217629142,
                "Median": 269.88938056934364,
                "Sd": 649.8553386841843,
                "Min": 0.0,
                "Max": 1409.8121543215138,
                "P90": 1222.7759281210056,
                "P95": 1297.5904186012085,
                "P99": 1387.3678071774527
            }
        },
        "benchmark_time": 65.5961332321167,
        "throughput_rps": 9.146880622930261,
        "throughput": 1392.246699616215,
        "total_output_token": 91326,
        "output_tokens_per_min": 83534.8019769729,
        "total_input_tokens": 155809,
        "input_tokens_per_min": 142516.6322978141,
        "total_tokens": 247135,
        "tokens_per_min": 226051.434274787,
        "avg_per_token_latency": 0.0036569072973450557,
        "median_per_token_latency": 0.0034740283898886605,
        "sd_per_token_latency": 0.003071672073261512,
        "min_per_token_latency": 4.899551264972608e-05,
        "max_per_token_latency": 0.00884265400011067,
        "p90_per_token_latency": 0.0076437872865507085,
        "p99_per_token_latency": 0.008510783360257386,
        "avg_latency": 1226.7800827821095,
        "median_latency": 511.0466480255127,
        "sd_latency": 1551.1855941265253,
        "min_latency": 27.27651596069336,
        "max_latency": 8406.78882598877,
        "p90_latency": 3140.7984495162964,
        "p99_latency": 7079.594633579254,
        "avg_per_output_token_latency": 10.459463619305247,
        "median_per_output_token_latency": 8.395869500941865,
        "sd_per_output_token_latency": 7.235342172410851,
        "min_per_output_token_latency": 6.7921394997454705,
        "max_per_output_token_latency": 50.68492889404297,
        "p90_per_output_token_latency": 13.925417264302574,
        "p99_per_output_token_latency": 46.67180061340331,
        "avg_input_len": 259.6816666666667,
        "median_input_len": 132.0,
        "sd_input_len": 285.44217802774386,
        "min_input_len": 4.0,
        "max_input_len": 1009.0,
        "p90_input_len": 741.6000000000001,
        "p99_input_len": 972.06,
        "avg_output_len": 152.21,
        "median_output_len": 61.5,
        "sd_output_len": 193.64896737826066,
        "min_output_len": 1.0,
        "max_output_len": 1007.0,
        "p90_output_len": 392.4000000000001,
        "p99_output_len": 876.1299999999999,
        "ClientConnectorError": 0,
        "TimeoutError": 0,
        "ContentTypeError": 0,
        "ClientOSError": 0,
        "ServerDisconnectedError": 0,
        "unknown_error": 0
    },
    ...
    }
}
```

### Yaml to deploy the new image

```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: benchmark-tool
    generated-by: benchmark-catalog-cli
  name: benchmark-tool
  namespace: c1-l7b-vllm-h100-epp-pod-refresh-r8-test-new-lpg
spec:
  replicas: 1
  selector:
    matchLabels:
      app: benchmark-tool
      generated-by: benchmark-catalog-cli
  template:
    metadata:
      labels:
        app: benchmark-tool
        generated-by: benchmark-catalog-cli
    spec:
      containers:
      - command:
        - bash
        - -c
        - ./latency_throughput_curve.sh
        env:
        - name: IP
          value: 'model-server-service.c1-l7b-vllm-h100-epp-pod-refresh-r8-test-new-lpg.svc.cluster.local'
        - name: REQUEST_RATES
          value: '10'
        - name: TOKENIZER
          value: 'meta-llama/Llama-2-7b-hf'
        - name: MODELS
          value: 'meta-llama/Llama-2-7b-hf'
        - name: BENCHMARK_TIME_SECONDS
          value: '10'
        - name: BACKEND
          value: vllm
        - name: PORT
          value: "8081"
        - name: INPUT_LENGTH
          value: "1024"
        - name: OUTPUT_LENGTH
          value: '2048'
        - name: FILE_PREFIX
          value: benchmark-catalog
        - name: SCRAPE_SERVER_METRICS
          value: "true"
        - name: PM_NAMESPACE
          value: c1-l7b-vllm-h100-epp-pod-refresh-r8-test-new-lpg
        - name: PM_JOB
          value: model-server-monitoring
        - name: PROMPT_DATASET_FILE
          value: ShareGPT_V3_unfiltered_cleaned_split.json
        - name: HF_TOKEN
          valueFrom:
            secretKeyRef:
              key: hf_api_token
              name: hf-secret
        image: 'us-docker.pkg.dev/gke-inference-gateway-dev/benchmark/benchmark-tool:new-metrics'
```