### PR TITLE
Should not expect `latency` in result if `errors` is not null

### DIFF
--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -476,25 +476,27 @@ async def benchmark(
         if res is None:
             continue
         latency, ttft, itl, errors = res
-        prompt_len, output_len, request_latency = latency
-        overall_results["latencies"].append(latency)
-        if ttft:
-            overall_results["ttfts"].append(ttft)
-            overall_results["tpots"].append((request_latency - ttft) / (output_len - 1) if output_len > 1 else 0)
-        if itl:
-            overall_results["itls"].extend(itl)
         if errors:
             for k, v in errors.items():
                 overall_results["errors"][k] += v
-        per_model_results[chosen_model]["latencies"].append(latency)
-        if ttft:
-            per_model_results[chosen_model]["ttfts"].append(ttft)
-            per_model_results[chosen_model]["tpots"].append((request_latency - ttft) / (output_len - 1) if output_len > 1 else 0)
-        if itl:
-            per_model_results[chosen_model]["itls"].extend(itl)
-        if errors:
-            for k, v in errors.items():
-                per_model_results[chosen_model]["errors"][k] += v
+        else:
+          prompt_len, output_len, request_latency = latency
+          overall_results["latencies"].append(latency)
+          if ttft:
+              overall_results["ttfts"].append(ttft)
+              overall_results["tpots"].append((request_latency - ttft) / (output_len - 1) if output_len > 1 else 0)
+          if itl:
+              overall_results["itls"].extend(itl)
+
+          per_model_results[chosen_model]["latencies"].append(latency)
+          if ttft:
+              per_model_results[chosen_model]["ttfts"].append(ttft)
+              per_model_results[chosen_model]["tpots"].append((request_latency - ttft) / (output_len - 1) if output_len > 1 else 0)
+          if itl:
+              per_model_results[chosen_model]["itls"].extend(itl)
+          if errors:
+              for k, v in errors.items():
+                  per_model_results[chosen_model]["errors"][k] += v
 
     benchmark_duration = time.time() - benchmark_start_time
     

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -477,26 +477,21 @@ async def benchmark(
             continue
         latency, ttft, itl, errors = res
         if errors:
-            for k, v in errors.items():
-                overall_results["errors"][k] += v
+          for k, v in errors.items():
+              overall_results["errors"][k] += v
+              per_model_results[chosen_model]["errors"][k] += v
         else:
           prompt_len, output_len, request_latency = latency
           overall_results["latencies"].append(latency)
+          per_model_results[chosen_model]["latencies"].append(latency)
           if ttft:
               overall_results["ttfts"].append(ttft)
               overall_results["tpots"].append((request_latency - ttft) / (output_len - 1) if output_len > 1 else 0)
-          if itl:
-              overall_results["itls"].extend(itl)
-
-          per_model_results[chosen_model]["latencies"].append(latency)
-          if ttft:
               per_model_results[chosen_model]["ttfts"].append(ttft)
               per_model_results[chosen_model]["tpots"].append((request_latency - ttft) / (output_len - 1) if output_len > 1 else 0)
           if itl:
-              per_model_results[chosen_model]["itls"].extend(itl)
-          if errors:
-              for k, v in errors.items():
-                  per_model_results[chosen_model]["errors"][k] += v
+              overall_results["itls"].extend(itl)     
+              per_model_results[chosen_model]["itls"].extend(itl)     
 
     benchmark_duration = time.time() - benchmark_start_time
     


### PR DESCRIPTION
fixes: https://github.com/AI-Hypercomputer/inference-benchmark/issues/11