### PR TITLE
Add `--ignore-eos` flag

### DIFF
--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -157,6 +157,7 @@ async def send_stream_request(
     prompt: str,
     prompt_len: int,
     output_len: int,
+    ignore_eos: bool,
     best_of: int,
     use_beam_search: bool,
     top_k: int,
@@ -180,7 +181,7 @@ async def send_stream_request(
         "temperature": 0.0 if use_beam_search else 1.0,
         "top_p": 1.0,
         "max_tokens": output_len,
-        "ignore_eos": True,
+        "ignore_eos": ignore_eos,
         "stream": True,
     }
   elif backend == "jetstream":
@@ -264,6 +265,7 @@ async def send_request(
     prompt: str,
     prompt_len: int,
     output_len: int,
+    ignore_eos: bool,
     best_of: int,
     use_beam_search: bool,
     top_k: int,
@@ -287,7 +289,7 @@ async def send_request(
         "temperature": 0.0 if use_beam_search else 1.0,
         "top_p": 1.0,
         "max_tokens": output_len,
-        "ignore_eos": False,
+        "ignore_eos": ignore_eos,
         "stream": False,
     }
   elif backend == "tgi":
@@ -418,11 +420,11 @@ async def run_single_request(args: argparse.Namespace, api_url: str, tokenizer: 
                                prompt: str, prompt_len: int, output_len: int, chosen_model: str) -> Tuple[str, Tuple]:
     if args.stream_request:
         result = await send_stream_request(
-            args.backend, api_url, prompt, prompt_len, output_len,
+            args.backend, api_url, prompt, prompt_len, output_len, args.ignore_eos,
             args.best_of, args.use_beam_search, args.top_k, tokenizer, args.sax_model, chosen_model, args.request_timeout,)
     else:
         result = await send_request(
-            args.backend, api_url, prompt, prompt_len, output_len,
+            args.backend, api_url, prompt, prompt_len, output_len, args.ignore_eos,
             args.best_of, args.use_beam_search, args.top_k, tokenizer, args.sax_model, chosen_model, args.request_timeout,)
     return chosen_model, result
 
@@ -972,6 +974,14 @@ if __name__ == "__main__":
       help=(
           "Maximum number of input tokens for filtering the benchmark dataset."
       ),
+  )
+  parser.add_argument(
+    "--ignore-eos",
+    action="store_true",
+    help=(
+        "If set, the generation process will ignore the end-of-sequence (EOS) token, "
+        "allowing output to continue until reaching --max-output-length or another stopping condition."
+    ),
   )
   parser.add_argument(
       "--top-k",

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -979,7 +979,7 @@ if __name__ == "__main__":
     "--ignore-eos",
     action="store_true",
     help=(
-        "If set, the generation process will ignore the end-of-sequence (EOS) token, "
+        "If set and model server is vllm, the generation process will ignore the end-of-sequence (EOS) token, "
         "allowing output to continue until reaching --max-output-length or another stopping condition."
     ),
   )


### PR DESCRIPTION
Results with `--ignore-eos`:
```
python3 benchmark_serving.py --scrape-server-metrics --save-json-results --host=vllm-inference-server --port=8000 --model=meta-llama/Llama-2-7b-hf --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=meta-llama/Llama-2-7b-hf --request-rate=10 --backend=vllm --num-prompts=100 --max-input-length=1024 --max-output-length=2048 --save-aggregated-result --pm-namespace= --pm-job= --ignore-eos
```

```
====Result for Model: weighted====
Errors: {'ClientConnectorError': 0, 'TimeoutError': 0, 'ContentTypeError': 0, 'ClientOSError': 0, 'ServerDisconnectedError': 0, 'unknown_error': 0}
Total time: 124.76 s
Successful/total requests: 100/100
Requests/min: 48.09
Output_tokens/min: 13530.96
Input_tokens/min: 13015.89
Tokens/min: 26546.85
Average seconds/token (includes waiting time on server): 0.08
Average milliseconds/request (includes waiting time on server): 39549.75
Average milliseconds/output_token (includes waiting time on server): 443.50
Average input length: 270.64
Average output length: 281.35
```


Results without `--ignore-eos`:
```
python3 benchmark_serving.py --scrape-server-metrics --save-json-results --host=vllm-inference-server --port=8000 --model=meta-llama/Llama-2-7b-hf --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=meta-llama/Llama-2-7b-hf --request-rate=10 --backend=vllm --num-prompts=100 --max-input-length=1024 --max-output-length=2048 --save-aggregated-result --pm-namespace= --pm-job=
```

```
====Result for Model: weighted====
Errors: {'ClientConnectorError': 0, 'TimeoutError': 0, 'ContentTypeError': 0, 'ClientOSError': 0, 'ServerDisconnectedError': 0, 'unknown_error': 0}
Total time: 105.05 s
Successful/total requests: 100/100
Requests/min: 57.12
Output_tokens/min: 11936.87
Input_tokens/min: 14158.15
Tokens/min: 26095.02
Average seconds/token (includes waiting time on server): 0.07
Average milliseconds/request (includes waiting time on server): 23369.89
Average milliseconds/output_token (includes waiting time on server): 190.94
Average input length: 247.88
Average output length: 208.99
```