### PR TITLE
Make units of time consistent across metrics

### DIFF
--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -167,7 +167,7 @@ async def send_stream_request(
     timeout: float,
 ) -> Tuple[Tuple[int, int, float], float, List[float], Dict[str, int]]:
   """Sends stream request to server"""
-  request_start_time = 1000 * time.time()
+  request_start_time_ms = 1000 * time.time()
   errors = init_errors_map()
 
   headers = {"User-Agent": "Benchmark Client"}
@@ -244,15 +244,15 @@ async def send_stream_request(
       print(f"Unknown error {e}")
       errors["unknown_error"] += 1
       return None, None, None, errors
-  request_end_time = 1000 * time.time()
+  request_end_time_ms = 1000 * time.time()
   output_token_ids = tokenizer(output).input_ids
   output_len = len(output_token_ids)
-  request_latency = (prompt_len, output_len, (request_end_time - request_start_time))
+  request_latency = (prompt_len, output_len, (request_end_time_ms - request_start_time_ms))
 
   # Exclude first token for tpot calculation
   if output_len > 1:
-    tpot_metric.observe((request_end_time - ttft - request_start_time) / (output_len - 1))
-  request_latency_per_output_token_metric.observe((request_end_time - request_start_time) / output_len)
+    tpot_metric.observe((request_end_time_ms - ttft - request_start_time_ms) / (output_len - 1))
+  request_latency_per_output_token_metric.observe((request_end_time_ms - request_start_time_ms) / output_len)
   if ttft is not None:
     ttft_metric.observe(ttft)
   prompt_length_metric.observe(prompt_len)
@@ -275,7 +275,7 @@ async def send_request(
     timeout: float,
 ) -> Tuple[Tuple[int, int, float], float, List[float], Dict[str, int]]:
   """Sends request to server."""
-  request_start_time = 1000 * time.time()
+  request_start_time_ms = 1000 * time.time()
   errors = init_errors_map()
 
   headers = {"User-Agent": "Benchmark Client"}
@@ -381,7 +381,7 @@ async def send_request(
         errors["unknown_error"] += 1
         return None, None, None, errors
 
-  request_end_time = 1000 * time.time()
+  request_end_time_ms = 1000 * time.time()
   # Naive HF transformers generation and TensorRT-LLM generation stops at EOS
   # tokens and the generation may be shorter than the ground-truth output
   # sequence length.
@@ -408,8 +408,8 @@ async def send_request(
     output_len = len(output_token_ids)
 
   # (prompt len, output len, latency, success)
-  request_latency = (prompt_len, output_len, (request_end_time - request_start_time))
-  request_latency_per_output_token_metric.observe((request_end_time - request_start_time) / output_len)
+  request_latency = (prompt_len, output_len, (request_end_time_ms - request_start_time_ms))
+  request_latency_per_output_token_metric.observe((request_end_time_ms - request_start_time_ms) / output_len)
   prompt_length_metric.observe(prompt_len)
   response_length_metric.observe(output_len)
 
@@ -804,9 +804,9 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
   itls_stats = {}
   tpot_stats = {}
   if args.stream_request:
-    ttft_stats = get_stats_for_set("TTFT", "Time to First Token (s)", ttfts)
-    itls_stats = get_stats_for_set("ITL", "Inter-Token Latency (s)", itls)
-    tpot_stats = get_stats_for_set("TPOT", "Time Per Output Token (s)", tpots)
+    ttft_stats = get_stats_for_set("TTFT_ms", "Time to First Token (ms)", ttfts)
+    itls_stats = get_stats_for_set("ITL_ms", "Inter-Token Latency (ms)", itls)
+    tpot_stats = get_stats_for_set("TPOT_ms", "Time Per Output Token (ms)", tpots)
   if args.machine_cost:
     print(
         "Cost $/1k tokens:"

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -815,7 +815,7 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
 
   benchmark_result = {
     **benchmark_result,
-    **(get_stats_for_set("per_token_latency", "seconds/token (includes waiting time on server)", [
+    **(get_stats_for_set("per_token_latency", "milliseconds/token (includes waiting time on server)", [
       latency / (prompt_len + output_len)
       for prompt_len, output_len, latency in request_latencies
     ])),

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -815,7 +815,7 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
 
   benchmark_result = {
     **benchmark_result,
-    **(get_stats_for_set("per_token_latency_ms", "milliseconds/token (includes waiting time on server)", [
+    **(get_stats_for_set("per_token_latency_ms", "milliseconds/token (includes waiting time on server) in milliseconds", [
       latency / (prompt_len + output_len)
       for prompt_len, output_len, latency in request_latencies
     ])),
@@ -823,8 +823,8 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
     **itls_stats,
     # NOTE: The latency below includes requests awaiting time on server side.
     # It's not comparable with the model inference latency for batch size 1.
-    **(get_stats_for_set("latency_ms", "milliseconds/request (includes waiting time on server)" ,[latency for _, _, latency in request_latencies])),
-    **(get_stats_for_set("per_output_token_latency_ms", "milliseconds/output_token (includes waiting time on server)", [latency / output_len for _, output_len, latency in request_latencies])),
+    **(get_stats_for_set("latency_ms", "milliseconds/request (includes waiting time on server) in milliseconds" ,[latency for _, _, latency in request_latencies])),
+    **(get_stats_for_set("per_output_token_latency_ms", "milliseconds/output_token (includes waiting time on server) in milliseconds", [latency / output_len for _, output_len, latency in request_latencies])),
     **(get_stats_for_set("input_len", "input length", [float(prompt_len) for prompt_len, _, _ in request_latencies])),
     **(get_stats_for_set("output_len", "output length", [float(output_len) for _, output_len, _ in request_latencies]))
   }

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -545,13 +545,13 @@ def save_json_results(args: argparse.Namespace, benchmark_result, server_metrics
       "stats": [{
         "request_rate": args.request_rate,
         "request_latency": {
-          "mean": benchmark_result["avg_latency"],
-          "median": benchmark_result["median_latency"],
-          "sd": benchmark_result["sd_latency"],
-          "min": benchmark_result["min_latency"],
-          "max": benchmark_result["max_latency"],
-          "p90": benchmark_result["p90_latency"],
-          "p99": benchmark_result["p99_latency"],
+          "mean": benchmark_result["avg_latency_ms"],
+          "median": benchmark_result["median_latency_ms"],
+          "sd": benchmark_result["sd_latency_ms"],
+          "min": benchmark_result["min_latency_ms"],
+          "max": benchmark_result["max_latency_ms"],
+          "p90": benchmark_result["p90_latency_ms"],
+          "p99": benchmark_result["p99_latency_ms"],
         },
         "throughput": {
           "mean": benchmark_result['throughput']
@@ -575,13 +575,13 @@ def save_json_results(args: argparse.Namespace, benchmark_result, server_metrics
           "p99": benchmark_result["p99_output_len"],
         },
         "tpot": {
-          "mean": benchmark_result["avg_per_output_token_latency"],
-          "median": benchmark_result["median_per_output_token_latency"],
-          "sd": benchmark_result["sd_per_output_token_latency"],
-          "min": benchmark_result["min_per_output_token_latency"],
-          "max": benchmark_result["max_per_output_token_latency"],
-          "p90": benchmark_result["p90_per_output_token_latency"],
-          "p99": benchmark_result["p99_per_output_token_latency"],
+          "mean": benchmark_result["avg_per_output_token_latency_ms"],
+          "median": benchmark_result["median_per_output_token_latency_ms"],
+          "sd": benchmark_result["sd_per_output_token_latency_ms"],
+          "min": benchmark_result["min_per_output_token_latency_ms"],
+          "max": benchmark_result["max_per_output_token_latency_ms"],
+          "p90": benchmark_result["p90_per_output_token_latency_ms"],
+          "p99": benchmark_result["p99_per_output_token_latency_ms"],
         },
         "model_server_metrics" : [{"Name": name, **metrics} for name, metrics in server_metrics.items()]
       }]
@@ -823,8 +823,8 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
     **itls_stats,
     # NOTE: The latency below includes requests awaiting time on server side.
     # It's not comparable with the model inference latency for batch size 1.
-    **(get_stats_for_set("latency", "milliseconds/request (includes waiting time on server)" ,[latency for _, _, latency in request_latencies])),
-    **(get_stats_for_set("per_output_token_latency", "milliseconds/output_token (includes waiting time on server)", [latency / output_len for _, output_len, latency in request_latencies])),
+    **(get_stats_for_set("latency_ms", "milliseconds/request (includes waiting time on server)" ,[latency for _, _, latency in request_latencies])),
+    **(get_stats_for_set("per_output_token_latency_ms", "milliseconds/output_token (includes waiting time on server)", [latency / output_len for _, output_len, latency in request_latencies])),
     **(get_stats_for_set("input_len", "input length", [float(prompt_len) for prompt_len, _, _ in request_latencies])),
     **(get_stats_for_set("output_len", "output length", [float(output_len) for _, output_len, _ in request_latencies]))
   }

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -774,7 +774,7 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
   print(f"Errors: {errors}")
   print(f"Total time: {benchmark_duration:.2f} s")
   print(f"Successful/total requests: {len(request_latencies)}/{total_requests}")
-  print(f"Requests/min: {60 * total_requests / benchmark_duration:.2f}")
+  print(f"Requests/sec: {total_requests / benchmark_duration:.2f}")
   benchmark_result["num_prompts_attempted"] = total_requests
   benchmark_result["num_prompts_succeeded"] = len(request_latencies)
   benchmark_result['benchmark_time'] = benchmark_duration
@@ -785,23 +785,21 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
   output_tokens_per_second = total_output_tokens / benchmark_duration
   benchmark_result['throughput'] = output_tokens_per_second
 
-  output_tokens_per_min = 60 * output_tokens_per_second
-  print(f"Output_tokens/min: {output_tokens_per_min:.2f}")
+  print(f"Output_tokens/sec: {output_tokens_per_second:.2f}")
   benchmark_result['total_output_token'] = int(total_output_tokens)
-  benchmark_result['output_tokens_per_min'] = output_tokens_per_min
 
   total_input_tokens = np.sum([prompt_len for prompt_len, _, _ in
                                request_latencies])
-  input_tokens_per_min = 60 * total_input_tokens / benchmark_duration
-  print(f"Input_tokens/min: {input_tokens_per_min:.2f}")
+  input_tokens_per_sec = total_input_tokens / benchmark_duration
+  print(f"Input_tokens/sec: {input_tokens_per_sec:.2f}")
   benchmark_result['total_input_tokens'] = int(total_input_tokens)
-  benchmark_result['input_tokens_per_min'] = input_tokens_per_min
+  benchmark_result['input_tokens_per_sec'] = input_tokens_per_sec
 
   total_tokens = total_input_tokens + total_output_tokens
-  tokens_per_min = 60 * total_tokens / benchmark_duration
-  print(f"Tokens/min: {tokens_per_min:.2f}")
+  tokens_per_sec = total_tokens / benchmark_duration
+  print(f"Tokens/sec: {tokens_per_sec:.2f}")
   benchmark_result['total_tokens'] = int(total_tokens)
-  benchmark_result['tokens_per_min'] = tokens_per_min
+  benchmark_result['tokens_per_sec'] = tokens_per_sec
   ttft_stats = {}
   itls_stats = {}
   tpot_stats = {}
@@ -812,7 +810,7 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
   if args.machine_cost:
     print(
         "Cost $/1k tokens:"
-        f" {args.machine_cost * 1000 / (60 * output_tokens_per_min)}"
+        f" {args.machine_cost * 1000 / output_tokens_per_second}"
     )
 
   benchmark_result = {

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -49,9 +49,9 @@ PROMETHEUS_PORT = 9090
 # Prometheus Metrics
 prompt_length_metric = Histogram("LatencyProfileGenerator:prompt_length", "Input prompt length", buckets=[2**i for i in range(1, 16)])
 response_length_metric = Histogram("LatencyProfileGenerator:response_length", "Response length", buckets=[2**i for i in range(1, 16)])
-request_latency_per_output_token_metric = Histogram('LatencyProfileGenerator:request_latency_per_output_token_ms', 'Time per output token per request (including first token) in milliseconds')
-tpot_metric = Histogram('LatencyProfileGenerator:time_per_output_token_ms', 'Time per output token per request (excluding first token) in milliseconds')
-ttft_metric = Histogram('LatencyProfileGenerator:time_to_first_token_ms', 'Time to first token per request')
+request_latency_per_output_token_metric = Histogram('LatencyProfileGenerator:request_latency_per_output_token_ms', 'Time per output token per request (including first token) in milliseconds', buckets=[2**i for i in range(1, 16)])
+tpot_metric = Histogram('LatencyProfileGenerator:time_per_output_token_ms', 'Time per output token per request (excluding first token) in milliseconds', buckets=[2**i for i in range(1, 16)])
+ttft_metric = Histogram('LatencyProfileGenerator:time_to_first_token_ms', 'Time to first token per request in milliseconds', buckets=[2**i for i in range(1, 16)])
 active_requests_metric = Gauge('LatencyProfileGenerator:active_requests', 'How many requests actively being processed')
 
 # Add trace config for monitoring in flight requests

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -195,7 +195,7 @@ async def send_stream_request(
 
   ttft = 0.0
   itl = []
-  st = time.perf_counter()
+  st = 1000 * time.perf_counter()
   most_recent_timestamp = st
   output = ""
   timeout = aiohttp.ClientTimeout(total=timeout)
@@ -206,7 +206,7 @@ async def send_stream_request(
           chunk_bytes = chunk_bytes[0].strip()
           if not chunk_bytes:
               continue
-          timestamp = time.perf_counter()
+          timestamp = 1000 * time.perf_counter()
           # First token
           if ttft == 0.0:
             ttft = timestamp - st
@@ -815,7 +815,7 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
 
   benchmark_result = {
     **benchmark_result,
-    **(get_stats_for_set("per_token_latency", "milliseconds/token (includes waiting time on server)", [
+    **(get_stats_for_set("per_token_latency_ms", "milliseconds/token (includes waiting time on server)", [
       latency / (prompt_len + output_len)
       for prompt_len, output_len, latency in request_latencies
     ])),

--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -49,9 +49,9 @@ PROMETHEUS_PORT = 9090
 # Prometheus Metrics
 prompt_length_metric = Histogram("LatencyProfileGenerator:prompt_length", "Input prompt length", buckets=[2**i for i in range(1, 16)])
 response_length_metric = Histogram("LatencyProfileGenerator:response_length", "Response length", buckets=[2**i for i in range(1, 16)])
-request_latency_per_output_token_metric = Histogram('LatencyProfileGenerator:request_latency_per_output_token', 'Time per output token per request (including first token)')
-tpot_metric = Histogram('LatencyProfileGenerator:time_per_output_token', 'Time per output token per request (excluding first token)')
-ttft_metric = Histogram('LatencyProfileGenerator:time_to_first_token', 'Time to first token per request')
+request_latency_per_output_token_metric = Histogram('LatencyProfileGenerator:request_latency_per_output_token_ms', 'Time per output token per request (including first token) in milliseconds')
+tpot_metric = Histogram('LatencyProfileGenerator:time_per_output_token_ms', 'Time per output token per request (excluding first token) in milliseconds')
+ttft_metric = Histogram('LatencyProfileGenerator:time_to_first_token_ms', 'Time to first token per request')
 active_requests_metric = Gauge('LatencyProfileGenerator:active_requests', 'How many requests actively being processed')
 
 # Add trace config for monitoring in flight requests
@@ -251,10 +251,10 @@ async def send_stream_request(
 
   # Exclude first token for tpot calculation
   if output_len > 1:
-    tpot_metric.observe((request_end_time - ttft - request_start_time) / (output_len - 1))
-  request_latency_per_output_token_metric.observe((request_end_time - request_start_time) / output_len)
+    tpot_metric.observe(1000 * (request_end_time - ttft - request_start_time) / (output_len - 1))
+  request_latency_per_output_token_metric.observe(1000 * (request_end_time - request_start_time) / output_len)
   if ttft is not None:
-    ttft_metric.observe(ttft)
+    ttft_metric.observe(1000 * ttft)
   prompt_length_metric.observe(prompt_len)
   response_length_metric.observe(output_len)
   return request_latency, ttft, itl, None


### PR DESCRIPTION
Addresses: #5, #6, and #25

- All rates of tokens now expressed in `tokens/sec`
- All times except total benchmark time now expressed in `ms`

Example log output:
```
+ python3 benchmark_serving.py --save-json-results --host=vllm-inference-server --port=8000 --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=meta-llama/Llama-2-7b-hf --backend=vllm --max-input-length=1024 --max-output-length=1024 --file-prefix=benchmark --models=meta-llama/Llama-2-7b-hf --pm-namespace= --pm-job= --scrape-server-metrics --save-aggregated-result --stream-request --ignore-eos --request-rate=10 --num-prompts=100
+ cat latency-profile-2025-04-01_20-43-47.txt
Namespace(backend='vllm', sax_model='', file_prefix='benchmark', endpoint='generate', host='vllm-inference-server', port=8000, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', models='meta-llama/Llama-2-7b-hf', traffic_split=None, stream_request=True, request_timeout=10800.0, tokenizer='meta-llama/Llama-2-7b-hf', best_of=1, use_beam_search=False, num_prompts=100, max_input_length=1024, max_output_length=1024, ignore_eos=True, top_k=32000, request_rate=10.0, seed=1743540230, trust_remote_code=False, machine_cost=None, use_dummy_text=False, save_json_results=True, output_bucket=None, output_bucket_filepath=None, save_aggregated_result=True, additional_metadata_metrics_to_save=None, scrape_server_metrics=True, pm_namespace='', pm_job='')
Models to benchmark: ['meta-llama/Llama-2-7b-hf']
No traffic split specified. Defaulting to uniform traffic split.
Starting Prometheus Server on port 9090
====Result for Model: weighted====
Errors: {'ClientConnectorError': 0, 'TimeoutError': 0, 'ContentTypeError': 0, 'ClientOSError': 0, 'ServerDisconnectedError': 0, 'unknown_error': 0}
Total time (seconds): 87.84 s
Successful/total requests: 100/100
Requests/sec: 1.14
Output_tokens/sec: 254.39
Input_tokens/sec: 310.86
Tokens/sec: 565.25
Average Time to First Token (ms): 4726.53
Average Inter-Token Latency (ms): 100.03
Average Time Per Output Token (ms): 125.96
Average milliseconds/token (includes waiting time on server): 66.60
Average milliseconds/request (includes waiting time on server): 27019.61
Average milliseconds/output_token (includes waiting time on server): 187.45
Average input length: 273.06
Average output length: 223.46
====Result for Model: meta-llama/Llama-2-7b-hf====
Errors: {'ClientConnectorError': 0, 'TimeoutError': 0, 'ContentTypeError': 0, 'ClientOSError': 0, 'ServerDisconnectedError': 0, 'unknown_error': 0}
Total time (seconds): 87.84 s
Successful/total requests: 100/100
Requests/sec: 1.14
Output_tokens/sec: 254.39
Input_tokens/sec: 310.86
Tokens/sec: 565.25
Average Time to First Token (ms): 4726.53
Average Inter-Token Latency (ms): 100.03
Average Time Per Output Token (ms): 125.96
Average milliseconds/token (includes waiting time on server): 66.60
Average milliseconds/request (includes waiting time on server): 27019.61
Average milliseconds/output_token (includes waiting time on server): 187.45
Average input length: 273.06
Average output length: 223.46
```

Example metrics:
```
# HELP LatencyProfileGenerator:normalized_time_per_output_token_ms Request time over total number of tokens (including first token) (ms)
# TYPE LatencyProfileGenerator:normalized_time_per_output_token_ms histogram
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="2.0"} 0.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="4.0"} 0.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="8.0"} 0.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="16.0"} 0.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="32.0"} 0.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="64.0"} 0.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="128.0"} 49.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="256.0"} 91.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="512.0"} 96.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="1024.0"} 97.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="2048.0"} 100.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="4096.0"} 100.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="8192.0"} 100.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="16384.0"} 100.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="32768.0"} 100.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_bucket{le="+Inf"} 100.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_count 100.0
LatencyProfileGenerator:normalized_time_per_output_token_ms_sum 18745.47210125365
# HELP LatencyProfileGenerator:normalized_time_per_output_token_ms_created Request time over total number of tokens (including first token) (ms)
# TYPE LatencyProfileGenerator:normalized_time_per_output_token_ms_created gauge
LatencyProfileGenerator:normalized_time_per_output_token_ms_created 1.743540230772589e+09
# HELP LatencyProfileGenerator:time_per_output_token_ms Time per output token per request (excluding first token) (ms)
# TYPE LatencyProfileGenerator:time_per_output_token_ms histogram
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="2.0"} 0.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="4.0"} 0.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="8.0"} 0.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="16.0"} 0.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="32.0"} 0.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="64.0"} 0.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="128.0"} 71.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="256.0"} 97.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="512.0"} 99.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="1024.0"} 100.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="2048.0"} 100.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="4096.0"} 100.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="8192.0"} 100.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="16384.0"} 100.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="32768.0"} 100.0
LatencyProfileGenerator:time_per_output_token_ms_bucket{le="+Inf"} 100.0
LatencyProfileGenerator:time_per_output_token_ms_count 100.0
LatencyProfileGenerator:time_per_output_token_ms_sum 12596.000242429498
# HELP LatencyProfileGenerator:time_per_output_token_ms_created Time per output token per request (excluding first token) (ms)
# TYPE LatencyProfileGenerator:time_per_output_token_ms_created gauge
LatencyProfileGenerator:time_per_output_token_ms_created 1.7435402307727385e+09
# HELP LatencyProfileGenerator:time_to_first_token_ms Time to first token per request (ms)
# TYPE LatencyProfileGenerator:time_to_first_token_ms histogram
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="2.0"} 0.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="4.0"} 0.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="8.0"} 0.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="16.0"} 0.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="32.0"} 0.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="64.0"} 0.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="128.0"} 2.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="256.0"} 10.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="512.0"} 32.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="1024.0"} 55.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="2048.0"} 79.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="4096.0"} 88.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="8192.0"} 88.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="16384.0"} 88.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="32768.0"} 96.0
LatencyProfileGenerator:time_to_first_token_ms_bucket{le="+Inf"} 100.0
LatencyProfileGenerator:time_to_first_token_ms_count 100.0
LatencyProfileGenerator:time_to_first_token_ms_sum 472653.264292717
# HELP LatencyProfileGenerator:time_to_first_token_ms_created Time to first token per request (ms)
# TYPE LatencyProfileGenerator:time_to_first_token_ms_created gauge
LatencyProfileGenerator:time_to_first_token_ms_created 1.7435402307727852e+09
```

Output report snippets:
```
      "benchmark_time":87.84033846855164,
      "throughput_rps":1.1384291288426869,
      "throughput":254.39337313118682,
      "total_output_token":22346,
      "total_input_tokens":27306,
      "input_tokens_per_sec":310.8594579217841,
      "total_tokens":49652,
      "tokens_per_sec":565.2528310529709,
      "avg_per_token_latency_ms":66.6024823499567,
      "median_per_token_latency_ms":72.05563393043431,
      "sd_per_token_latency_ms":48.07966757659292,
      "min_per_token_latency_ms":2.6810149079436187,
      "max_per_token_latency_ms":238.66333477313702,
      "p90_per_token_latency_ms":111.28895124966199,
      "p99_per_token_latency_ms":208.02486801858666,
      "avg_TTFT_ms":4726.53264292717,
      "median_TTFT_ms":960.1973071098328,
      "sd_TTFT_ms":10178.969625507814,
      "min_TTFT_ms":86.44172406196594,
      "max_TTFT_ms":41286.71972107887,
      "p90_TTFT_ms":26576.437416243556,
      "p99_TTFT_ms":36785.07510749819,
      "avg_ITL_ms":100.0284871989902,
      "median_ITL_ms":87.32730805873871,
      "sd_ITL_ms":201.7994172398057,
      "min_ITL_ms":0.008500099182128906,
      "max_ITL_ms":19921.434350967407,
      "p90_ITL_ms":91.23337912559509,
      "p99_ITL_ms":371.6477309107781,
      "avg_latency_ms":27019.610415039064,
      "median_latency_ms":23990.890625,
      "sd_latency_ms":22649.636453719995,
      "min_latency_ms":1806.07763671875,
      "max_latency_ms":82286.05737304688,
      "p90_latency_ms":59655.363720703164,
      "p99_latency_ms":78119.30447753909,
      "avg_normalized_time_per_output_token_ms":187.45472101253642,
      "median_normalized_time_per_output_token_ms":128.56888836194574,
      "sd_normalized_time_per_output_token_ms":212.4174757311342,
      "min_normalized_time_per_output_token_ms":85.09416481183752,
      "max_normalized_time_per_output_token_ms":1390.1640735973012,
      "p90_normalized_time_per_output_token_ms":242.68255231990372,
      "p99_normalized_time_per_output_token_ms":1218.0888416637083,
      "avg_input_len":273.06,
      "median_input_len":114.0,
      "sd_input_len":294.59819483493106,
      "min_input_len":4.0,
      "max_input_len":1014.0,
      "p90_input_len":754.5000000000002,
      "p99_input_len":966.4800000000002,
      "avg_output_len":223.46,
      "median_output_len":164.0,
      "sd_output_len":225.18456519042326,
      "min_output_len":8.0,
      "max_output_len":967.0,
      "p90_output_len":511.9000000000001,
      "p99_output_len":867.0100000000006,
      "ClientConnectorError":0,
      "TimeoutError":0,
      "ContentTypeError":0,
      "ClientOSError":0,
      "ServerDisconnectedError":0,
      "unknown_error":0
```
```
             "request_rate":10.0,
            "request_latency":{
               "mean":27019.610415039064,
               "median":23990.890625,
               "sd":22649.636453719995,
               "min":1806.07763671875,
               "max":82286.05737304688,
               "p90":59655.363720703164,
               "p99":78119.30447753909
            },
            "throughput":{
               "mean":254.39337313118682
            },
            "input_length":{
               "mean":273.06,
               "median":114.0,
               "sd":294.59819483493106,
               "min":4.0,
               "max":1014.0,
               "p90":754.5000000000002,
               "p99":966.4800000000002
            },
            "output_length":{
               "mean":223.46,
               "median":164.0,
               "sd":225.18456519042326,
               "min":8.0,
               "max":967.0,
               "p90":511.9000000000001,
               "p99":867.0100000000006
            },
            "tpot":{
               "mean":187.45472101253642,
               "median":128.56888836194574,
               "sd":212.4174757311342,
               "min":85.09416481183752,
               "max":1390.1640735973012,
               "p90":242.68255231990372,
               "p99":1218.0888416637083
            },
```