### PR TITLE
Fix dict access on missing metrics

### DIFF
--- a/benchmark_serving.py
+++ b/benchmark_serving.py
@@ -672,10 +672,10 @@ def print_metrics(metrics: List[str], duration: float, namespace: str, job: str)
 
   for metric in metrics:
     # Find metric type
+    if metric not in all_metrics_metadata['data']:
+      logger.debug(f"No metric found for {metric}")
+      continue
     metric_type = all_metrics_metadata['data'][metric]
-    if all_metrics_metadata['data'][metric] is None:
-      print("No metric found for: %s" % metric)
-      return
     metric_type = metric_type[0]['type']
 
     metric_results = {}


### PR DESCRIPTION
vLLM v1 has removed some metrics in the expected list that causes print_metrics to fail.

Fixes #28 


Tested against vllm v0.8.2

```
python3 benchmark_serving.py --save-json-results --host=llama3-8b-vllm-service --port=8000 --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=meta-llama/Meta-Llama-3-8B --request-rate=50 --backend=vllm --num-prompts=10 --max-input-length=1024 --max-output-length=1024 --file-prefix=benchmark --models=meta-llama/Meta-Llama-3-8B --output-bucket='' --scrape-server-metrics
Namespace(backend='vllm', sax_model='', file_prefix='benchmark', endpoint='generate', host='llama3-8b-vllm-service', port=8000, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', models='meta-llama/Meta-Llama-3-8B', traffic_split=None, stream_request=False, request_timeout=10800.0, tokenizer='meta-llama/Meta-Llama-3-8B', best_of=1, use_beam_search=False, num_prompts=10, max_input_length=1024, max_output_length=1024, ignore_eos=False, top_k=32000, request_rate=50.0, seed=1743522630, trust_remote_code=False, machine_cost=None, use_dummy_text=False, save_json_results=True, output_bucket='', output_bucket_filepath=None, save_aggregated_result=False, additional_metadata_metrics_to_save=None, scrape_server_metrics=True, pm_namespace='default', pm_job='vllm-podmonitoring')
====Result for Model: meta-llama/Meta-Llama-3-8B====
Errors: {'ClientConnectorError': 0, 'TimeoutError': 0, 'ContentTypeError': 0, 'ClientOSError': 0, 'ServerDisconnectedError': 0, 'unknown_error': 0}
Total time: 29.33 s
Successful/total requests: 10/10
Requests/min: 20.46
Output_tokens/min: 1972.08
Input_tokens/min: 3545.25
Tokens/min: 5517.33
Average seconds/token (includes waiting time on server): 0.03
Average milliseconds/request (includes waiting time on server): 6380.57
Average milliseconds/output_token (includes waiting time on server): 92.62
Average input length: 173.30
Average output length: 96.40
```