### PR TITLE
`--ignore-eos` now configurable via `IGNORE_EOS` env var

### DIFF
--- a/latency_throughput_curve.sh
+++ b/latency_throughput_curve.sh
@@ -46,6 +46,7 @@ BASE_PYTHON_OPTS=(
 [[ "$SCRAPE_SERVER_METRICS" = "true" ]] && BASE_PYTHON_OPTS+=("--scrape-server-metrics")
 [[ "$SAVE_AGGREGATED_RESULT" = "true" ]] && BASE_PYTHON_OPTS+=("--save-aggregated-result")
 [[ "$STREAM_REQUEST" = "true" ]] && BASE_PYTHON_OPTS+=("--stream-request")
+[[ "$IGNORE_EOS" = "true" ]] && BASE_PYTHON_OPTS+=("--ignore-eos")
 [[ "$OUTPUT_BUCKET_FILEPATH" ]] && BASE_PYTHON_OPTS+=("--output-bucket-filepath" "$OUTPUT_BUCKET_FILEPATH")
 
 SLEEP_TIME=${SLEEP_TIME:-0}


### PR DESCRIPTION
Fixes: #30 

Example run:
```
IP="vllm-inference-server" MODELS="meta-llama/Llama-2-7b-hf" TOKENIZER="meta-llama/Llama-2-7b-hf" PROMPT_DATASET="sharegpt" BACKEND="vllm" INPUT_LENGTH="1024" OUTPUT_LENGTH="1024" REQUEST_RATES="10" MAX_NUM_PROMPTS="100" SCRAPE_SERVER_METRICS="true" SAVE_AGGREGATED_RESULT="true" STREAM_REQUEST="true" BENCHMARK_TIME_SECONDS="10" IGNORE_EOS="true" ./latency_throughput_curve.sh
+ export IP=vllm-inference-server
+ IP=vllm-inference-server
+ huggingface-cli login --token xxxxx --add-to-git-credential
Token is valid (permission: read).
The token `local` has been saved to /root/.cache/huggingface/stored_tokens
Your token has been saved in your configured git credential helpers (store).
Your token has been saved to /root/.cache/huggingface/token
Login successful.
Note: Environment variable`HF_TOKEN` is set and is the current active token independently from the token you've just configured.
+ [[ sharegpt = \s\h\a\r\e\g\p\t ]]
+ PROMPT_DATASET_FILE=ShareGPT_V3_unfiltered_cleaned_split.json
+ PYTHON=python3
+ BASE_PYTHON_OPTS=("benchmark_serving.py" "--save-json-results" "--host=$IP" "--port=$PORT" "--dataset=$PROMPT_DATASET_FILE" "--tokenizer=$TOKENIZER" "--backend=$BACKEND" "--max-input-length=$INPUT_LENGTH" "--max-output-length=$OUTPUT_LENGTH" "--file-prefix=$FILE_PREFIX" "--models=$MODELS" "--pm-namespace=$PM_NAMESPACE" "--pm-job=$PM_JOB")
+ [[ -n '' ]]
+ [[ -n '' ]]
+ [[ true = \t\r\u\e ]]
+ BASE_PYTHON_OPTS+=("--scrape-server-metrics")
+ [[ true = \t\r\u\e ]]
+ BASE_PYTHON_OPTS+=("--save-aggregated-result")
+ [[ true = \t\r\u\e ]]
+ BASE_PYTHON_OPTS+=("--stream-request")
+ [[ true = \t\r\u\e ]]
+ BASE_PYTHON_OPTS+=("--ignore-eos")
+ [[ -n '' ]]
+ SLEEP_TIME=0
++ echo 10
++ tr , ' '
+ for request_rate in $(echo $REQUEST_RATES | tr ',' ' ')
+ echo 'Benchmarking request rate: 10'
Benchmarking request rate: 10
++ date +%Y-%m-%d_%H-%M-%S
+ timestamp=xxxxx
+ output_file=xxxxx
+ '[' 10 == 0 ']'
++ awk 'BEGIN {print int(10 * 10)}'
+ num_prompts=100
+ echo 'TOTAL prompts: 100'
TOTAL prompts: 100
+ PYTHON_OPTS=("${BASE_PYTHON_OPTS[@]}" "--request-rate=$request_rate" "--num-prompts=$num_prompts")
+ python3 benchmark_serving.py --save-json-results --host=vllm-inference-server --port=8000 --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=meta-llama/Llama-2-7b-hf --backend=vllm --max-input-length=1024 --max-output-length=1024 --file-prefix=benchmark --models=meta-llama/Llama-2-7b-hf --pm-namespace= --pm-job= --scrape-server-metrics --save-aggregated-result --stream-request --ignore-eos --request-rate=10 --num-prompts=100
+ cat latency-profile-2025-04-01_20-29-58.txt
Namespace(backend='vllm', sax_model='', file_prefix='benchmark', endpoint='generate', host='vllm-inference-server', port=8000, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', models='meta-llama/Llama-2-7b-hf', traffic_split=None, stream_request=True, request_timeout=10800.0, tokenizer='meta-llama/Llama-2-7b-hf', best_of=1, use_beam_search=False, num_prompts=100, max_input_length=1024, max_output_length=1024, ignore_eos=True, top_k=32000, request_rate=10.0, seed=1743539401, trust_remote_code=False, machine_cost=None, use_dummy_text=False, save_json_results=True, output_bucket=None, output_bucket_filepath=None, save_aggregated_result=True, additional_metadata_metrics_to_save=None, scrape_server_metrics=True, pm_namespace='', pm_job='')
Models to benchmark: ['meta-llama/Llama-2-7b-hf']
No traffic split specified. Defaulting to uniform traffic split.
Starting Prometheus Server on port 9090
====Result for Model: weighted====
Errors: {'ClientConnectorError': 0, 'TimeoutError': 0, 'ContentTypeError': 0, 'ClientOSError': 0, 'ServerDisconnectedError': 0, 'unknown_error': 0}
Total time (seconds): 86.87 s
Successful/total requests: 100/100
Requests/sec: 1.15
Output_tokens/sec: 288.59
Input_tokens/sec: 232.95
Tokens/sec: 521.54
Average Time to First Token (ms): 8712.47
Average Inter-Token Latency (ms): 96.08
Average Time Per Output Token (ms): 104.65
Average milliseconds/token (includes waiting time on server) in milliseconds: 94.49
Average milliseconds/request (includes waiting time on server) in milliseconds: 32720.75
Average milliseconds/output_token (includes waiting time on server) in milliseconds: 282.57
Average input length: 202.36
Average output length: 250.69
====Result for Model: meta-llama/Llama-2-7b-hf====
Errors: {'ClientConnectorError': 0, 'TimeoutError': 0, 'ContentTypeError': 0, 'ClientOSError': 0, 'ServerDisconnectedError': 0, 'unknown_error': 0}
Total time (seconds): 86.87 s
Successful/total requests: 100/100
Requests/sec: 1.15
Output_tokens/sec: 288.59
Input_tokens/sec: 232.95
Tokens/sec: 521.54
Average Time to First Token (ms): 8712.47
Average Inter-Token Latency (ms): 96.08
Average Time Per Output Token (ms): 104.65
Average milliseconds/token (includes waiting time on server) in milliseconds: 94.49
Average milliseconds/request (includes waiting time on server) in milliseconds: 32720.75
Average milliseconds/output_token (includes waiting time on server) in milliseconds: 282.57
Average input length: 202.36
Average output length: 250.69
+ echo 'Sleeping for 0 seconds...'
Sleeping for 0 seconds...
+ sleep 0
+ export LPG_FINISHED=true
+ LPG_FINISHED=true
+ sleep infinity
```

