### PR TITLE
Make final sleep duration configurable in latency_throughput_curve.sh

### DIFF
--- a/latency_throughput_curve.sh
+++ b/latency_throughput_curve.sh
@@ -50,6 +50,7 @@ BASE_PYTHON_OPTS=(
 [[ "$OUTPUT_BUCKET_FILEPATH" ]] && BASE_PYTHON_OPTS+=("--output-bucket-filepath" "$OUTPUT_BUCKET_FILEPATH")
 
 SLEEP_TIME=${SLEEP_TIME:-0}
+POST_BENCHMARK_SLEEP_TIME=${POST_BENCHMARK_SLEEP_TIME:-infinity}
 
 for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
   echo "Benchmarking request rate: ${request_rate}"
@@ -74,4 +75,4 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
 done
 
 export LPG_FINISHED="true"
-sleep infinity
+sleep $POST_BENCHMARK_SLEEP_TIME


### PR DESCRIPTION
**Description:**

introduces the ability to configure the duration for which the `latency_throughput_curve.sh` script will sleep after all benchmark operations are complete.

Previously, the script would `sleep infinity` at the end. This change introduces a new environment variable, `POST_BENCHMARK_SLEEP_TIME`, which allows users to specify this duration.

**Key Changes:**

*   The `POST_BENCHMARK_SLEEP_TIME` environment variable is now used to control the final sleep duration.
*   If `POST_BENCHMARK_SLEEP_TIME` is not set, it defaults to `infinity`, ensuring backward compatibility with the previous behavior.

**Motivation:**

This enhancement provides users with more flexibility, particularly in containerized environments. By configuring the final sleep time, users can:
*   Keep the container alive for a specific period to inspect logs.
*   Allow other processes or sidecars to access generated benchmark results before the container terminates.

**How to Use:**

Set the `POST_BENCHMARK_SLEEP_TIME` environment variable to the desired sleep duration in seconds (e.g., `POST_BENCHMARK_SLEEP_TIME=300` for 5 minutes). If unset, it will sleep indefinitely.