### PR TITLE
upload to spanner and add min input and output len

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.20-slim-bookworm as dev
+FROM python:3.9.20-slim-bookworm AS dev
 
 RUN apt-get update -y \
     && apt-get install -y python3-pip git vim curl wget

--- a/latency_throughput_curve.sh
+++ b/latency_throughput_curve.sh
@@ -1,27 +1,15 @@
 #!/bin/bash
-
-# Copyright 2024 Google Inc. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+set -euo pipefail
 set -o xtrace
 
-export IP=$IP
+export IP=${IP:-localhost}
 
-huggingface-cli login --token "$HF_TOKEN" --add-to-git-credential
+huggingface-cli login --token "${HF_TOKEN:-}" --add-to-git-credential || true
 
-if [[ "$PROMPT_DATASET" = "sharegpt" ]]; then
+if [[ "${PROMPT_DATASET:-}" == "sharegpt" ]]; then
   PROMPT_DATASET_FILE="ShareGPT_V3_unfiltered_cleaned_split.json"
+else
+  PROMPT_DATASET_FILE="${PROMPT_DATASET_FILE:-$PROMPT_DATASET}"
 fi
 
 PYTHON="python3"
@@ -29,7 +17,7 @@ BASE_PYTHON_OPTS=(
   "benchmark_serving.py"
   "--save-json-results"
   "--host=$IP"
-  "--port=$PORT"
+  "--port=${PORT:-7080}"
   "--dataset=$PROMPT_DATASET_FILE"
   "--tokenizer=$TOKENIZER"
   "--backend=$BACKEND"
@@ -37,50 +25,54 @@ BASE_PYTHON_OPTS=(
   "--max-output-length=$OUTPUT_LENGTH"
   "--file-prefix=$FILE_PREFIX"
   "--models=$MODELS"
-  "--pm-namespace=$PM_NAMESPACE"
-  "--pm-job=$PM_JOB"
+  "--pm-namespace=${PM_NAMESPACE:-default}"
+  "--pm-job=${PM_JOB:-vllm-podmonitoring}"
 )
 
-[[ "$MIN_INPUT_LENGTH" ]] && BASE_PYTHON_OPTS+=("--min-input-length=$MIN_INPUT_LENGTH")
-[[ "$MIN_OUTPUT_LENGTH" ]] && BASE_PYTHON_OPTS+=("--min-output-length=$MIN_OUTPUT_LENGTH")
-[[ "$OUTPUT_BUCKET" ]] && BASE_PYTHON_OPTS+=("--output-bucket=$OUTPUT_BUCKET")
-[[ "$TRAFFIC_SPLIT" ]] && BASE_PYTHON_OPTS+=("--traffic-split=$TRAFFIC_SPLIT")
-[[ "$OUTPUT_BUCKET" ]] && BASE_PYTHON_OPTS+=("--output-bucket=$OUTPUT_BUCKET")
-[[ "$SCRAPE_SERVER_METRICS" = "true" ]] && BASE_PYTHON_OPTS+=("--scrape-server-metrics")
-[[ "$SAVE_AGGREGATED_RESULT" = "true" ]] && BASE_PYTHON_OPTS+=("--save-aggregated-result")
-[[ "$STREAM_REQUEST" = "true" ]] && BASE_PYTHON_OPTS+=("--stream-request")
-[[ "$IGNORE_EOS" = "true" ]] && BASE_PYTHON_OPTS+=("--ignore-eos")
-[[ "$OUTPUT_BUCKET_FILEPATH" ]] && BASE_PYTHON_OPTS+=("--output-bucket-filepath" "$OUTPUT_BUCKET_FILEPATH")
-[[ "$TCP_CONN_LIMIT" ]] && BASE_PYTHON_OPTS+=("--tcp-conn-limit" "$TCP_CONN_LIMIT")
-[[ "$SPANNER_INSTANCE_ID" ]] && BASE_PYTHON_OPTS+=("--spanner-instance-id" "$SPANNER_INSTANCE_ID")
-[[ "$SPANNER_DATABASE_ID" ]] && BASE_PYTHON_OPTS+=("--spanner-database-id" "$SPANNER_DATABASE_ID")
+[[ "${MIN_INPUT_LENGTH:-}" ]]        && BASE_PYTHON_OPTS+=("--min-input-length=$MIN_INPUT_LENGTH")
+[[ "${MIN_OUTPUT_LENGTH:-}" ]]       && BASE_PYTHON_OPTS+=("--min-output-length=$MIN_OUTPUT_LENGTH")
+[[ "${OUTPUT_BUCKET:-}" ]]           && BASE_PYTHON_OPTS+=("--output-bucket=$OUTPUT_BUCKET")
+[[ "${TRAFFIC_SPLIT:-}" ]]           && BASE_PYTHON_OPTS+=("--traffic-split=$TRAFFIC_SPLIT")
+[[ "${SCRAPE_SERVER_METRICS:-}" == "true" ]] && BASE_PYTHON_OPTS+=("--scrape-server-metrics")
+[[ "${SAVE_AGGREGATED_RESULT:-}" == "true" ]] && BASE_PYTHON_OPTS+=("--save-aggregated-result")
+[[ "${STREAM_REQUEST:-}" == "true" ]] && BASE_PYTHON_OPTS+=("--stream-request")
+[[ "${IGNORE_EOS:-}" == "true" ]]     && BASE_PYTHON_OPTS+=("--ignore-eos")
+[[ "${OUTPUT_BUCKET_FILEPATH:-}" ]]   && BASE_PYTHON_OPTS+=("--output-bucket-filepath" "$OUTPUT_BUCKET_FILEPATH")
+[[ "${TCP_CONN_LIMIT:-}" ]]           && BASE_PYTHON_OPTS+=("--tcp-conn-limit" "$TCP_CONN_LIMIT")
+[[ "${SPANNER_INSTANCE_ID:-}" ]]      && BASE_PYTHON_OPTS+=("--spanner-instance-id" "$SPANNER_INSTANCE_ID")
+[[ "${SPANNER_DATABASE_ID:-}" ]]      && BASE_PYTHON_OPTS+=("--spanner-database-id" "$SPANNER_DATABASE_ID")
 
-
+# Support TARGETMODELS or TARGET_MODELS
+TARGETMODELS_EFFECTIVE="${TARGETMODELS:-${TARGET_MODELS:-}}"
+[[ "$TARGETMODELS_EFFECTIVE" ]] && BASE_PYTHON_OPTS+=("--targetmodels" "$TARGETMODELS_EFFECTIVE")
 
 SLEEP_TIME=${SLEEP_TIME:-0}
 POST_BENCHMARK_SLEEP_TIME=${POST_BENCHMARK_SLEEP_TIME:-infinity}
 
-for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
+if [[ -z "${REQUEST_RATES:-}" ]]; then
+  echo "ERROR: REQUEST_RATES is empty"; exit 1
+fi
+
+for request_rate in $(echo "$REQUEST_RATES" | tr ',' ' '); do
   echo "Benchmarking request rate: ${request_rate}"
-  # TODO: Check if profile already exists, if so then skip
   timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
   output_file="latency-profile-${timestamp}.txt"
-  
-  if [ "$request_rate" == "0" ]; then
+
+  if [[ "$request_rate" == "0" ]]; then
     request_rate="inf"
-    num_prompts=$MAX_NUM_PROMPTS
+    num_prompts="${MAX_NUM_PROMPTS:?Set MAX_NUM_PROMPTS when REQUEST_RATE=0}"
   else
-    num_prompts=$(awk "BEGIN {print int($request_rate * $BENCHMARK_TIME_SECONDS)}")
+    num_prompts=$(awk "BEGIN {print int($request_rate * ${BENCHMARK_TIME_SECONDS:-60})}")
   fi
 
   echo "TOTAL prompts: $num_prompts"
   PYTHON_OPTS=("${BASE_PYTHON_OPTS[@]}" "--request-rate=$request_rate" "--num-prompts=$num_prompts")
-  
+
   $PYTHON "${PYTHON_OPTS[@]}" > "$output_file"
   cat "$output_file"
   echo "Sleeping for $SLEEP_TIME seconds..."
-  sleep $SLEEP_TIME
+  sleep "$SLEEP_TIME"
 done
 
 export LPG_FINISHED="true"
-sleep $POST_BENCHMARK_SLEEP_TIME
+sleep "$POST_BENCHMARK_SLEEP_TIME"

--- a/latency_throughput_curve.sh
+++ b/latency_throughput_curve.sh
@@ -41,6 +41,9 @@ BASE_PYTHON_OPTS=(
   "--pm-job=$PM_JOB"
 )
 
+[[ "$MIN_INPUT_LENGTH" ]] && BASE_PYTHON_OPTS+=("--min-input-length=$MIN_INPUT_LENGTH")
+[[ "$MIN_OUTPUT_LENGTH" ]] && BASE_PYTHON_OPTS+=("--min-output-length=$MIN_OUTPUT_LENGTH")
+[[ "$OUTPUT_BUCKET" ]] && BASE_PYTHON_OPTS+=("--output-bucket=$OUTPUT_BUCKET")
 [[ "$TRAFFIC_SPLIT" ]] && BASE_PYTHON_OPTS+=("--traffic-split=$TRAFFIC_SPLIT")
 [[ "$OUTPUT_BUCKET" ]] && BASE_PYTHON_OPTS+=("--output-bucket=$OUTPUT_BUCKET")
 [[ "$SCRAPE_SERVER_METRICS" = "true" ]] && BASE_PYTHON_OPTS+=("--scrape-server-metrics")
@@ -49,6 +52,10 @@ BASE_PYTHON_OPTS=(
 [[ "$IGNORE_EOS" = "true" ]] && BASE_PYTHON_OPTS+=("--ignore-eos")
 [[ "$OUTPUT_BUCKET_FILEPATH" ]] && BASE_PYTHON_OPTS+=("--output-bucket-filepath" "$OUTPUT_BUCKET_FILEPATH")
 [[ "$TCP_CONN_LIMIT" ]] && BASE_PYTHON_OPTS+=("--tcp-conn-limit" "$TCP_CONN_LIMIT")
+[[ "$SPANNER_INSTANCE_ID" ]] && BASE_PYTHON_OPTS+=("--spanner-instance-id" "$SPANNER_INSTANCE_ID")
+[[ "$SPANNER_DATABASE_ID" ]] && BASE_PYTHON_OPTS+=("--spanner-database-id" "$SPANNER_DATABASE_ID")
+
+
 
 SLEEP_TIME=${SLEEP_TIME:-0}
 POST_BENCHMARK_SLEEP_TIME=${POST_BENCHMARK_SLEEP_TIME:-infinity}

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,10 @@ aioprometheus[starlette]
 pynvml == 11.5.0
 accelerate
 aiohttp
+
+# For Google Cloud Storage
 google-auth
 google-cloud-storage >= 2.18.2
 prometheus_client >= 0.21.0
+google-cloud-spanner
+google-api-core


### PR DESCRIPTION
This pull request introduces significant enhancements to the `benchmark_serving.py` script and related files, focusing on data validation, Spanner integration, and improved configurability for benchmarking datasets. Key changes include adding support for uploading benchmark results to Google Cloud Spanner, introducing minimum input/output length filters, and enabling additional arguments for dataset filtering and Spanner configuration.

### Enhancements to Benchmarking and Data Validation:
* Added `safe_json_value` function to handle NaN and Infinity values for JSON serialization, ensuring compatibility with Spanner and other systems. (`benchmark_serving.py`, [benchmark_serving.pyR45-R239](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eR45-R239))
* Introduced `min_input_len` and `min_output_len` parameters in `get_filtered_dataset` to filter datasets based on minimum sequence lengths. (`benchmark_serving.py`, [[1]](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eR299-R300) [[2]](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eL142-R339)

### Integration with Google Cloud Spanner:
* Implemented `upload_to_spanner_batch_with_retry` function to upload benchmark results to Spanner with retry logic for batch uploads. (`benchmark_serving.py`, [benchmark_serving.pyR45-R239](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eR45-R239))
* Added Spanner-related arguments (`--spanner-instance-id`, `--spanner-database-id`) to the CLI parser for configuring Spanner uploads. (`benchmark_serving.py`, [benchmark_serving.pyR1345-R1356](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eR1345-R1356))
* Modified `save_json_results` to optionally upload results to Spanner, controlled by the `spanner_upload` flag. (`benchmark_serving.py`, [benchmark_serving.pyR837-R847](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eR837-R847))

### Updates to Benchmark Workflow:
* Enhanced `async def benchmark` to pass minimum input/output lengths and enable Spanner uploads. (`benchmark_serving.py`, [[1]](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eL474-R671) [[2]](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eL537-R740)
* Updated `print_and_save_result` to support Spanner uploads and optional server metrics scraping. (`benchmark_serving.py`, [[1]](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eL818-R1026) [[2]](diffhunk://#diff-f3b0a7531418dfb6a0fe604295f0ffaf2b08d17c91a88f579aa1391ac2742a9eL885-R1096)

### Shell Script Modifications:
* Added support for `--min-input-length`, `--min-output-length`, `--spanner-instance-id`, and `--spanner-database-id` in `latency_throughput_curve.sh`. (`latency_throughput_curve.sh`, [[1]](diffhunk://#diff-2924f4534e374a728cdac028397d2df3f71f6a37823850ffbe16908bfce129bdR44-R46) [[2]](diffhunk://#diff-2924f4534e374a728cdac028397d2df3f71f6a37823850ffbe16908bfce129bdR55-R58)